### PR TITLE
Set default background color

### DIFF
--- a/lessish.css
+++ b/lessish.css
@@ -68,6 +68,7 @@ body {
 	padding: 72px 48px 84px;
 	margin: 0 auto;
 	color: rgb(60,60,60);
+	background-color: white;
 	-webkit-text-size-adjust: 100%; /* Stops Mobile Safari from auto-adjusting font-sizes */
 }
 


### PR DESCRIPTION
Because the `color` is being set, is good custom to provide the `background-color` that contrast with. If not, when the user modify the default background color from white to a darker one, text doesn't read.

Example:
![wiki-bg](https://cloud.githubusercontent.com/assets/145141/10439720/3c5f5aa4-7112-11e5-9d4a-d2171bcb9c42.png)
